### PR TITLE
Add model parts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+finetuning/model/model.7z.001 filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 finetuning/model/model.7z.001 filter=lfs diff=lfs merge=lfs -text
+finetuning/model/model.7z.002 filter=lfs diff=lfs merge=lfs -text
+finetuning/model/model.7z.003 filter=lfs diff=lfs merge=lfs -text
+finetuning/model/model.7z.004 filter=lfs diff=lfs merge=lfs -text
+finetuning/model/model.7z.005 filter=lfs diff=lfs merge=lfs -text

--- a/finetuning/model/model.7z.001
+++ b/finetuning/model/model.7z.001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f02ac9e896ae81329e64f9e4d5ae45a6cc67dec82bd83316df5ac53c83aae80
+size 1048576000

--- a/finetuning/model/model.7z.002
+++ b/finetuning/model/model.7z.002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:578ca2df3a7465acfe2fca4697addc750f580f009ce20604da0acad43fe5053d
+size 1048576000

--- a/finetuning/model/model.7z.003
+++ b/finetuning/model/model.7z.003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ec30186ffbf798352cbd590014338ea54ff2e51ec3d5436292d390a0c7d175d
+size 1048576000

--- a/finetuning/model/model.7z.004
+++ b/finetuning/model/model.7z.004
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:728afe11e251328d8994ab519ed3e37e89a853a1ffc89c409b74594994a39564
+size 1048576000

--- a/finetuning/model/model.7z.005
+++ b/finetuning/model/model.7z.005
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:331179c9651797f12232117b806dfb59c348e9c2c7c6062d7cc5b218f792dae0
+size 1018276815


### PR DESCRIPTION
This pull request adds a large machine learning model to the repository using Git LFS (Large File Storage). The model files are split into five parts to accommodate size limitations, and `.gitattributes` is updated to ensure proper handling of these files.

Model addition and configuration:

* Added five large model archive parts (`model.7z.001` through `model.7z.005`) to `finetuning/model/`, each tracked via Git LFS to handle their large size. [[1]](diffhunk://#diff-3c836f7b3b3946403ef32121eb3abaa6db783347e55d428b5f1a6456980ae63bR1-R3) [[2]](diffhunk://#diff-627e3e7e3c7b19b0e1bc3fea8c15248322e17770919d97a8c246b0adb07fb924R1-R3) [[3]](diffhunk://#diff-ce93558adc6b86f39d9ba24e3896e1ee3ff98e36ae4d0ae3324dd5ed38806b4fR1-R3) [[4]](diffhunk://#diff-4a37261ce870c37e5ef8286e352b8e7e017de8c74f6a64c5e5c4b803473c39e3R1-R3) [[5]](diffhunk://#diff-8c14aa2ec88b80092c09bdffdf24a6156511f778a7d206cb9c9bdc5527d631b1R1-R3)
* Updated `.gitattributes` to configure Git LFS for the new model files, ensuring correct storage and retrieval behavior.