### PR TITLE
Add git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.7z filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This pull request introduces a new Git LFS (Large File Storage) rule for handling `.7z` files. This ensures that any `.7z` archives added to the repository are managed efficiently by Git LFS, preventing large files from bloating the repository. 

- Repository configuration:
  * Added a `.gitattributes` entry to track all `.7z` files using Git LFS.